### PR TITLE
投稿画面から遷移するメニューセレクト画面実装

### DIFF
--- a/src/app/editor/editor-routing.module.ts
+++ b/src/app/editor/editor-routing.module.ts
@@ -1,12 +1,17 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { EditorComponent } from './editor/editor.component';
+import { SelectMenuComponent } from './select-menu/select-menu.component';
 
 const routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
     component: EditorComponent,
+  },
+  {
+    path: 'select-menu',
+    component: SelectMenuComponent,
   },
 ];
 

--- a/src/app/editor/editor.module.ts
+++ b/src/app/editor/editor.module.ts
@@ -8,9 +8,10 @@ import { MatInputModule } from '@angular/material/input';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { SelectMenuComponent } from './select-menu/select-menu.component';
 
 @NgModule({
-  declarations: [EditorComponent],
+  declarations: [EditorComponent, SelectMenuComponent],
   imports: [
     CommonModule,
     EditorRoutingModule,

--- a/src/app/editor/editor/editor.component.html
+++ b/src/app/editor/editor/editor.component.html
@@ -73,7 +73,9 @@
             </button>
 
             <h2 class="form__description">トレーニング内容を追加</h2>
-            <button mat-raised-button color="primary">追加</button>
+            <button mat-raised-button color="primary">
+              <a routerLink="select-menu">追加</a>
+            </button>
 
             <h2 class="form__description">今日の感想</h2>
             <mat-form-field appearance="outline">

--- a/src/app/editor/editor/editor.component.scss
+++ b/src/app/editor/editor/editor.component.scss
@@ -28,6 +28,9 @@
     text-align: center;
     padding: 0 120px;
   }
+  &__select-menu {
+    display: block;
+  }
 }
 
 .urls-wrapper {

--- a/src/app/editor/select-menu/select-menu.component.html
+++ b/src/app/editor/select-menu/select-menu.component.html
@@ -1,0 +1,92 @@
+<div class="container">
+  <div class="container container--select">
+    <div class="header">
+      <div class="header__inner">
+        <div class="header__actions"></div>
+        <div class="header__description">
+          <h2 class="header__title">トレーニングを追加</h2>
+          <div class="header__how-to">使い方説明</div>
+        </div>
+        <div class="header__search">
+          <div class="header__search-form">
+            <button mat-icon-button>
+              <mat-icon>search</mat-icon>
+            </button>
+            <p>トレーニングを検索</p>
+          </div>
+          <div class="header__sort-button">
+            <button class="header__sort-button" mat-icon-button>
+              <mat-icon>tune</mat-icon>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="menu">
+      <div class="library">
+        <div class="library__title">Library</div>
+        <div class="library__items">
+          <div class="library__item">
+            <div class="item-wrapper">
+              <div class="library__item-title">ベンチプレス</div>
+              <span class="library__item-tags">胸</span>
+              <span class="library__item-tags">上腕三頭筋</span>
+              <span class="library__item-tags">三角筋</span>
+            </div>
+            <button class="library__item-add" mat-icon-button>
+              <mat-icon>add_circle_outline</mat-icon>
+            </button>
+          </div>
+          <div class="library__item">
+            <div class="item-wrapper">
+              <div class="library__item-title">懸垂</div>
+              <span class="library__item-tags">広背筋</span>
+              <span class="library__item-tags">上腕二頭筋</span>
+            </div>
+            <button class="library__item-add" mat-icon-button>
+              <mat-icon>add_circle_outline</mat-icon>
+            </button>
+          </div>
+          <div class="library__item">
+            <div class="item-wrapper">
+              <div class="library__item-title">レッグプレス</div>
+              <span class="library__item-tags">大腿四頭筋</span>
+              <span class="library__item-tags">ハムストリングス</span>
+            </div>
+            <button class="library__item-add" mat-icon-button>
+              <mat-icon>add_circle_outline</mat-icon>
+            </button>
+          </div>
+          <div class="library__item">
+            <div class="item-wrapper">
+              <div class="library__item-title">デッドリフト</div>
+              <span class="library__item-tags">大腿四頭筋</span>
+              <span class="library__item-tags">ハムストリングス</span>
+              <span class="library__item-tags">背筋下部</span>
+              <span class="library__item-tags">お尻</span>
+            </div>
+            <button class="library__item-add" mat-icon-button>
+              <mat-icon>add_circle_outline</mat-icon>
+            </button>
+          </div>
+          <div class="library__item">
+            <div class="item-wrapper">
+              <div class="library__item-title">ベントオーバーロウ</div>
+              <span class="library__item-tags">広背筋</span>
+              <span class="library__item-tags">背筋</span>
+              <span class="library__item-tags">三角筋</span>
+            </div>
+            <button class="library__item-add" mat-icon-button>
+              <mat-icon>add_circle_outline</mat-icon>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div class="selected">
+        <div class="selected__title">Select</div>
+        <div class="selected__items">まだアイテムはありません</div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/editor/select-menu/select-menu.component.scss
+++ b/src/app/editor/select-menu/select-menu.component.scss
@@ -50,6 +50,7 @@
     padding-bottom: 4px;
   }
   &__item-tags {
+    padding: 4px;
     color: #9ca1a3;
     border: 1px solid #e0e1e3;
     background-color: #f7f7f9;

--- a/src/app/editor/select-menu/select-menu.component.scss
+++ b/src/app/editor/select-menu/select-menu.component.scss
@@ -1,0 +1,74 @@
+.header {
+  background: linear-gradient(-90deg, #232a49, #2f3e8a);
+  &__inner {
+    padding: 32px 40px 8px;
+  }
+  &__description {
+    margin-bottom: 32px;
+  }
+  &__title {
+    color: #fff;
+  }
+  &__how-to {
+    color: rgba(255, 255, 255, 0.6);
+  }
+  &__search {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  &__search-form {
+    display: flex;
+    color: rgba(255, 255, 255, 0.6);
+    align-items: center;
+    background: rgb(165 165 165 / 40%);
+    border-radius: 20px;
+    padding-right: 32px;
+    height: 24px;
+  }
+  &__sort-button {
+    color: #455cd7;
+  }
+}
+
+.library {
+  margin: 24px 16px;
+  &__title {
+    color: #9ca1a3;
+    padding-bottom: 24px;
+  }
+  &__item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-bottom: 24px;
+  }
+  &__item-title {
+    color: #1a2035;
+    font-weight: 700;
+    font-size: 24px;
+    padding-bottom: 4px;
+  }
+  &__item-tags {
+    color: #9ca1a3;
+    border: 1px solid #e0e1e3;
+    background-color: #f7f7f9;
+    margin-right: 8px;
+    overflow-wrap: break-word;
+  }
+  &__item-add {
+    color: #a3adf3;
+  }
+}
+
+.selected {
+  margin: 24px 16px;
+  &__title {
+    color: #9ca1a3;
+    padding-bottom: 24px;
+  }
+}
+
+.menu {
+  display: flex;
+}

--- a/src/app/editor/select-menu/select-menu.component.spec.ts
+++ b/src/app/editor/select-menu/select-menu.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SelectMenuComponent } from './select-menu.component';
+
+describe('SelectMenuComponent', () => {
+  let component: SelectMenuComponent;
+  let fixture: ComponentFixture<SelectMenuComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SelectMenuComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SelectMenuComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/editor/select-menu/select-menu.component.ts
+++ b/src/app/editor/select-menu/select-menu.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-select-menu',
+  templateUrl: './select-menu.component.html',
+  styleUrls: ['./select-menu.component.scss']
+})
+export class SelectMenuComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -11,7 +11,6 @@ body {
 
 .container {
   width: 100%;
-  padding: 0 24px;
   margin: 0 auto;
   background-color: #f0f2f5;
   overflow: hidden;
@@ -22,6 +21,14 @@ body {
     border-radius: 16px;
   }
   &--editor {
+    max-width: 800px;
+    margin: 48px auto 80px;
+    padding: 0 0 24px 0;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0px 1px 2px #c3bfbf;
+  }
+  &--select {
     max-width: 800px;
     margin: 48px auto 80px;
     padding: 0 0 24px 0;


### PR DESCRIPTION
feat #31 
以下のように実装いたしました。
Library画面とSelect画面の表示領域を変更する
アニメーションも追加予定ですが、別Issueで立てて対応いたします。


## 実装イメージ
![image](https://user-images.githubusercontent.com/63516648/100327113-2bf3b780-300e-11eb-863a-579babb2c28e.png)

## 参考画面イメージ
![image](https://user-images.githubusercontent.com/63516648/100326324-25b10b80-300d-11eb-9d80-22d3e6307c71.png)
